### PR TITLE
replace Crypt::PBKDF2 with Crypt::KeyDerivation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.12.0;
+use 5.012;
 use strict;
 use warnings FATAL => 'all';
 use ExtUtils::MakeMaker;
@@ -19,10 +19,9 @@ WriteMakefile(
         'Test::More' => 0,
     },
     PREREQ_PM => {
-        'Net::IP'            => 0,
-        'MIME::Base64'       => 0,
-        'Crypt::PBKDF2'      => 0,
-        'Crypt::Cipher::AES' => 0,
+        'Net::IP'              => 0,
+        'Crypt::KeyDerivation' => 0,
+        'Crypt::Cipher::AES'   => 0,
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Net-Address-IP-Cipher-*' },

--- a/lib/Net/Address/IP/Cipher.pm
+++ b/lib/Net/Address/IP/Cipher.pm
@@ -1,14 +1,13 @@
 package Net::Address::IP::Cipher 0.3;
 
-use 5.006;
+use 5.012;
 use strict;
 use warnings FATAL => 'all';
 
 use Carp;
 
 use Net::IP qw(:PROC);
-use MIME::Base64;
-use Crypt::PBKDF2;
+use Crypt::KeyDerivation qw(pbkdf2);
 use Crypt::Cipher::AES;
 
 =head1 NAME
@@ -46,9 +45,8 @@ specification from:
 
 =head1 PREREQUISITES
 
-This module requires Net::IP for v6/v4 handling, MIME::Base64 and 
-Crypt::PBKDF2 for the 128-key derivation from the password, and
-Crypt::Cipher::AES for the IPv6 enc/decryption part.
+This module requires L<Net::IP> for v6/v4 handling and L<CryptX> for
+all crypto stuff (L<Crypt::KeyDerivation>, L<Crypt::Cipher::AES>).
 
 =head1 METHODS
 
@@ -82,23 +80,7 @@ sub new {
     my $key;
 
     if ($params{'password'}) {
-        my $pbkdf2 = Crypt::PBKDF2->new(
-                        hash_class => 'HMACSHA1',
-                        iterations => 50000,
-                        output_len => 16,
-                        salt_len => 16,
-                        encoding => 'crypt',
-                     );
-
-        $key = $pbkdf2->generate($params{'password'}, 'ipcipheripcipher');
-        # we need to extract just the "key" part from PBKDF2 hash
-        my $pbhash = $pbkdf2->encode_string('ipcipheripcipher', $key);
-        my ($ehash) = ($1) if $pbhash =~ /HMACSHA1:50000:.*\$(.*)/;
-        my $ihash = MIME::Base64::decode($ehash);
-        my ($fhash) = ($1) if $ihash =~ /HMACSHA1:50000:.*\$(.*)/;
-        $key = MIME::Base64::decode($fhash);
-
-        # my $dec = unpack("H*", $key);
+        $key = pbkdf2($params{'password'}, 'ipcipheripcipher', 50000, 'SHA1', 16);
     }
     elsif ($params{'barekey'}) {
         $key = pack 'H*', $params{'barekey'};


### PR DESCRIPTION
As you are already using `Crypt::Cipher::AES` it may be a good idea to also use PBKDF2 from `Crypt::KeyDerivation` as it is part of the same distribution `CryptX` as AES module. You can get rid of dependency on `MIME::Base64` + `Crypt::PBKDF2`.
